### PR TITLE
Use relative paths instead of Pkg.dir()

### DIFF
--- a/src/available_datasets.jl
+++ b/src/available_datasets.jl
@@ -1,5 +1,5 @@
 function available_datasets()
-    package_directory = Pkg.dir("RDatasets", "data")
+    package_directory = joinpath(dirname(@__FILE__), "..", "data")
     for directory in readdir(package_directory)
         @printf "* Package: %s\n" directory
         for file in readdir(joinpath(package_directory, directory))

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,5 +1,5 @@
 function dataset(package_name::String, dataset_name::String)
-    basename = joinpath(Pkg.dir("RDatasets", "data"), package_name)
+    basename = joinpath(dirname(@__FILE__), "..", "data", package_name)
     
     rdaname = joinpath(basename, string(dataset_name, ".rda"))
     if isfile(rdaname)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -4,6 +4,6 @@ function datasets(package_name::String)
 end
 
 function datasets()
-	path = joinpath(Pkg.dir("RDatasets"), "doc", "datasets.csv")
+	path = joinpath(dirname(@__FILE__), "..", "doc", "datasets.csv")
 	readtable(path)
 end

--- a/src/make_help_index.jl
+++ b/src/make_help_index.jl
@@ -1,5 +1,5 @@
 function make_help_index(datasets_csv_name::String, output_file_dir::String)
-    output_file_dir = Pkg.dir("RDatasets", "doc")
+    output_file_dir = joinpath(dirname(@__FILE__), "..", "doc")
 
     output_file_name = joinpath(output_file_dir, "_JL_INDEX_")
     d = readtable(datasets_csv_name)
@@ -16,10 +16,10 @@ function make_help_index(datasets_csv_name::String, output_file_dir::String)
 end
 
 function make_help_index(name::String)
-    make_help_index(name, Pkg.dir("RDatasets", "doc"))
+    make_help_index(name, joinpath(dirname(@__FILE__), "..", "doc"))
 end
 
 function make_help_index()
-    datasets_filename = Pkg.dir("RDatasets", "doc", "datasets.csv")
-    make_help_index(datasets_filename, Pkg.dir("RDatasets", "doc"))
+    datasets_filename = joinpath(dirname(@__FILE__), "..", "doc", "datasets.csv")
+    make_help_index(datasets_filename, joinpath(dirname(@__FILE__), "..", "doc"))
 end

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -1,4 +1,4 @@
 function packages()
-	path = joinpath(Pkg.dir("RDatasets"), "doc", "packages.csv")
+	path = joinpath(dirname(@__FILE__), "..", "doc", "packages.csv")
 	readtable(path)
 end

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -9,7 +9,7 @@ module TestDatasets
 
     df = DataFrame(Package = fill("", n), Dataset = fill("", n))
     i = 1
-    package_directory = Pkg.dir("RDatasets", "data")
+    package_directory = joinpath(dirname(@__FILE__), "..", "data")
     for directory in readdir(package_directory)
         for file in readdir(joinpath(package_directory, directory))
             dataset = replace(file, r"(\.(rda|csv|gz))+$", "")


### PR DESCRIPTION
`Pkg.dir()` won't work if RDatasets is installed outside the standard package location, so use relative paths instead to access other files in the package. See https://github.com/JuliaLang/julia/issues/8679#issuecomment-75796502

Tests don't work on my machine before making this change, so I can't verify that it breaks nothing, but it shouldn't really affect anything. 