### PR TITLE
Point deprecation warning to unexported datasets

### DIFF
--- a/src/RDatasets.jl
+++ b/src/RDatasets.jl
@@ -8,5 +8,5 @@ module RDatasets
     include("datasets.jl")
     include("packages.jl")
 
-    Base.@deprecate available_datasets datasets
+    Base.@deprecate available_datasets RDatasets.datasets
 end


### PR DESCRIPTION
The `datasets` method is not exported, reflect this in the deprecation warning.