### PR TITLE
fix `UndefVarError` of `@sprintf` in Issue #55

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -28,5 +28,5 @@ function dataset(package_name::AbstractString, dataset_name::AbstractString)
                      rows_for_type_detect=get(Dataset_typedetect_rows, (package_name, dataset_name), 200))
         end
     end
-    error(@sprintf "Unable to locate dataset file %s or %s" rdaname csvname)
+    error("Unable to locate dataset file ", rdaname, " or ", csvname)
 end


### PR DESCRIPTION
For Julia `v1.0`, it is necessary to load `Printf` module before calling `@sprintf`.(#55 ) So there might be two ways to resolve this issue. One is to add dependence of `Printf` which might bring a new trouble for old versions. Another way is directly to use `error` function with substrings, as in this pull request.