### PR TITLE
Fix minor regression in datasets.jl

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -1,6 +1,6 @@
 function datasets(package_name::AbstractString)
 	d = datasets()
-	d[findfirst(isequal(package_name), d[:Package]), :]
+	d[findall(isequal(package_name), d[:Package]), :]
 end
 
 function datasets()


### PR DESCRIPTION
Prior to this changeset, calling RDatasets.datasets("package") would
return a DataFrame with only a single row if "package" was found (even
if there were more datasets in the package) or raise an error if
"package" was not found.  This change fixes the regression; all datasets
are now returned when "package" is found and an empty DataFrame is
returned if "package" is not found.