### PR TITLE
Fix open file handles

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -23,9 +23,11 @@ function dataset(package_name::AbstractString, dataset_name::AbstractString)
 
     csvname = joinpath(basename, string(dataset_name, ".csv.gz"))
     if isfile(csvname)
-        data = IOBuffer(read(GzipDecompressorStream(open(csvname,"r"))))
-        return DataFrame(CSV.File(data, delim=',', quotechar='\"', missingstring="NA",
+        return open(csvname,"r") do io
+            uncompressed = IOBuffer(read(GzipDecompressorStream(io)))
+            DataFrame(CSV.File(uncompressed, delim=',', quotechar='\"', missingstring="NA",
                  rows_for_type_detect=get(Dataset_typedetect_rows, (package_name, dataset_name), 200)))
+        end
     end
     error(@sprintf "Unable to locate dataset file %s or %s" rdaname csvname)
 end


### PR DESCRIPTION
In the previous PR (https://github.com/johnmyleswhite/RDatasets.jl/pull/62) I was inattentive while writing the IO handling: When providing data from a CSV the file wasn't properly closed, but relied on the finalizer to do so. This PR fixes the behaviour by using a `do` construct. 